### PR TITLE
add & expand targets

### DIFF
--- a/lib/targets.js
+++ b/lib/targets.js
@@ -53,7 +53,7 @@ module.exports = [
     'HISTORY',
     '*LICENSE.*',
     'LICENSE',
-    'logo.*',
+    '*logo.*',
     'npm-debug.log',
     'spec/',
     'test.js',


### PR DESCRIPTION
Sorted alphabetically (was hard check before adding)
changed:
- `logo.*` gif, svg, etc
- grunt/gulpfile`.*` .coffee, .ls (LiveScript), etc
- add `LICENSE`, `*LICENSE.*`, `doc/` (perhaps questionable, but who runs these via CLI or in-app?

Note: I think occasionally READMEs are read; IIRC atom editor uses them directly.

Thanks for your project!
