### PR TITLE
remove gnode

### DIFF
--- a/bin/dmn
+++ b/bin/dmn
@@ -7,12 +7,11 @@ var path = require('path'),
 /**
  * Prepare spawn arguments
  */
-var gnode = require.resolve('gnode/bin/gnode'),
-    dmnCli = path.join(__dirname, '../lib/cli'),
+var dmnCli = path.join(__dirname, '../lib/cli'),
     args = [dmnCli].concat(process.argv.slice(2));
 
 
 /**
- * Spawn gnode
+ * Spawn node
  */
-spawn(gnode, args, { stdio: 'inherit' }).on('exit', process.exit);
+spawn(process.execPath, args, { stdio: 'inherit' }).on('exit', process.exit);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
-    "alter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
-      "requires": {
-        "stable": "~0.1.3"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -34,21 +21,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-    },
-    "asap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-      "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0="
-    },
-    "ast-traverse": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
-      "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY="
-    },
-    "ast-types": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz",
-      "integrity": "sha1-BCBbcu3dGVqP6qCB8R0ClKJN7ZM="
     },
     "async": {
       "version": "0.1.22",
@@ -68,11 +40,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "breakable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
-      "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME="
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -129,11 +96,6 @@
       "resolved": "https://registry.npmjs.org/co-read/-/co-read-0.0.1.tgz",
       "integrity": "sha1-+Bs+uKhmdf7FHj2IOn9WToc8k4k="
     },
-    "commander": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -146,29 +108,6 @@
       "dev": true,
       "requires": {
         "ms": "2.0.0"
-      }
-    },
-    "defs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defs/-/defs-1.0.1.tgz",
-      "integrity": "sha1-ufIylZl7lWWy8JE0RksY72s32/s=",
-      "requires": {
-        "alter": "~0.2.0",
-        "ast-traverse": "~0.1.1",
-        "breakable": "~1.0.0",
-        "esprima": "git://github.com/ariya/esprima.git#a65a3eb93b9a5dce9a1184ca2d1bd0b184c6b8fd",
-        "simple-fmt": "~0.1.0",
-        "simple-is": "~0.2.0",
-        "stringmap": "~0.2.2",
-        "stringset": "~0.2.1",
-        "tryor": "~0.1.2",
-        "yargs": "~1.3.2"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "git://github.com/ariya/esprima.git#a65a3eb93b9a5dce9a1184ca2d1bd0b184c6b8fd",
-          "from": "git://github.com/ariya/esprima.git#harmony"
-        }
       }
     },
     "diff": {
@@ -190,11 +129,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
-    },
-    "esprima-fb": {
-      "version": "7001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-7001.1.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-kH4gkZV1pmfdG0IzXeAM9mRtd7M="
     },
     "fs-extra": {
       "version": "0.12.0",
@@ -253,14 +187,6 @@
             "path-is-absolute": "^1.0.0"
           }
         }
-      }
-    },
-    "gnode": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/gnode/-/gnode-0.1.0.tgz",
-      "integrity": "sha1-GQ+0Q+rSZ+33c0fN4CAIVBJG/Mk=",
-      "requires": {
-        "regenerator": "~0.6.3"
       }
     },
     "graceful-fs": {
@@ -399,57 +325,12 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
-    },
-    "promise": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-6.0.1.tgz",
-      "integrity": "sha1-1HXP+BwIOif+h64ZlStywaaTYjc=",
-      "requires": {
-        "asap": "~1.0.0"
-      }
-    },
     "read": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
       "integrity": "sha1-AHo9FpR4qnEKSRcn5FPv+5LnYgM=",
       "requires": {
         "mute-stream": "~0.0.4"
-      }
-    },
-    "recast": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
-      "integrity": "sha1-9wkhu59zfY4fsGpEAxW9fsFFh8k=",
-      "requires": {
-        "ast-types": "~0.6.1",
-        "esprima-fb": "~10001.1.0-dev-harmony-fb",
-        "private": "~0.1.5",
-        "source-map": "~0.1.40"
-      },
-      "dependencies": {
-        "esprima-fb": {
-          "version": "10001.1.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-9++0UtPIAG3eazxZZ4YE9xFKiCw="
-        }
-      }
-    },
-    "regenerator": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.6.10.tgz",
-      "integrity": "sha1-/7y2KJq2t2saq3y7QoANwryWRP4=",
-      "requires": {
-        "commander": "~2.3.0",
-        "defs": "~1.0.1",
-        "esprima-fb": "~7001.1.0-dev-harmony-fb",
-        "private": "~0.1.5",
-        "promise": "~6.0.0",
-        "recast": "~0.9.0",
-        "through": "~2.3.6"
       }
     },
     "rimraf": {
@@ -466,39 +347,6 @@
       "integrity": "sha1-jvqjBPHxSM89LpVYYpkPmrnqYo8=",
       "dev": true
     },
-    "simple-fmt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-      "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms="
-    },
-    "simple-is": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-      "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA="
-    },
-    "source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-      "requires": {
-        "amdefine": ">=0.0.4"
-      }
-    },
-    "stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
-    },
-    "stringmap": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-      "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE="
-    },
-    "stringset": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-      "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU="
-    },
     "supports-color": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -508,20 +356,10 @@
         "has-flag": "^3.0.0"
       }
     },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
     "thunkify": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
-    },
-    "tryor": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-      "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys="
     },
     "win-fork": {
       "version": "1.1.1",
@@ -532,11 +370,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "yargs": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
-      "integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "git://github.com/inikulin/dmn.git"
   },
   "scripts": {
-    "test": "./node_modules/.bin/gnode test/run_tests.js"
+    "test": "node test/run_tests.js"
   },
   "dependencies": {
     "char-spinner": "1.0.1",
@@ -36,7 +36,6 @@
     "co-fs-extra": "0.0.2",
     "du": "0.1.0",
     "globby": "^2.1.0",
-    "gnode": "0.1.0",
     "nopt": "3.0.1",
     "read": "1.0.5",
     "thunkify": "2.1.2",


### PR DESCRIPTION
Currently supported versions of Node.js (6.x, 8.x, 10.x) have
generators. No need for gnode. Semver major change, though.