### PR TITLE
make clean recursive

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -38,11 +38,11 @@ function percentsLess(newVal, oldVal) {
  */
 function getCleanTargets() {
     var directDeps = targets.map(function (pattern) {
-            return '*/' + pattern;
+            return '**/' + pattern;
         }),
 
         indirectDeps = targets.map(function (pattern) {
-            return '**/node_modules/*/' + pattern;
+            return '**/node_modules/**/' + pattern;
         });
 
     return directDeps.concat(indirectDeps);

--- a/lib/targets.js
+++ b/lib/targets.js
@@ -93,7 +93,6 @@ module.exports = [
     'test/',
     'testing/',
     'tests/',
-    'tmp/',
     'tsconfig.json',
     'tslint.json',
     'tslint.yaml',
@@ -101,7 +100,6 @@ module.exports = [
     'Vagrantfile',
     'VERSIONS',
     'VERSIONS.*',
-    'webpack.config.js',
     'yarn-error.log',
     'yarn.lock*'
 ];

--- a/test/fixtures/clean.test.js
+++ b/test/fixtures/clean.test.js
@@ -12,6 +12,7 @@ var filesToClean = [
         'node_modules/yo/.travis.yml',
         'node_modules/yo/.eslintignore',
         'node_modules/yo/yarn.lock',
+        'node_modules/yo/src/main.d.ts',
         'node_modules/awesome_package/.gitignore',
         'node_modules/awesome_package/Gruntfile.js',
         'node_modules/yo/node_modules/yoyo/yo.pyc',


### PR DESCRIPTION
Turns out `clean` was not set to act recursively, missing a lot of files. This will result in some quite big gains, for example using a freshly created react app:

#### Before
````
INFO: 1376 item(s) are set for deletion
INFO: Deleting...
OK: Done! Your node_modules directory size was 108844.92 Kb but now it's 97552.58 Kb which is 10.4% less.
````

#### After
````
INFO: 4171 item(s) are set for deletion
INFO: Deleting...
OK: Done! Your node_modules directory size was 108844.92 Kb but now it's 83840.80 Kb which is 23.0% less.
````