### PR TITLE
remove targets that could result in breakage

### DIFF
--- a/lib/targets.js
+++ b/lib/targets.js
@@ -93,6 +93,7 @@ module.exports = [
     'test/',
     'testing/',
     'tests/',
+    'tmp/',
     'tsconfig.json',
     'tslint.json',
     'tslint.yaml',

--- a/lib/targets.js
+++ b/lib/targets.js
@@ -93,7 +93,6 @@ module.exports = [
     'test/',
     'testing/',
     'tests/',
-    'tmp/',
     'tsconfig.json',
     'tslint.json',
     'tslint.yaml',
@@ -101,7 +100,6 @@ module.exports = [
     'Vagrantfile',
     'VERSIONS',
     'VERSIONS.*',
-    'webpack.config.js',
     'yarn-error.log',
     'yarn.lock*'
 ];


### PR DESCRIPTION
I noticed these two targets while cleaning a react app recursively (e.g. including indirect depdendencies).  While react apps are currently working, breakage is possible for modules that depend directly on the affected modules.