### PR TITLE
Fix cleaning of peer dependencies

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -43,15 +43,7 @@ function percentsLess(newVal, oldVal) {
  * Create array of patterns which will be used for cleaning
  */
 function getCleanTargets() {
-    var directDeps = targets.map(function (pattern) {
-            return '*/' + pattern;
-        }),
-
-        indirectDeps = targets.map(function (pattern) {
-            return '**/node_modules/**/' + pattern;
-        });
-
-    return directDeps.concat(indirectDeps);
+    return ['(*/|**/node_modules/**/)(' + targets.join('|') + ')'];
 }
 
 

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -48,7 +48,7 @@ function getCleanTargets() {
         }),
 
         indirectDeps = targets.map(function (pattern) {
-            return '**/node_modules/*/' + pattern;
+            return '**/node_modules/**/' + pattern;
         });
 
     return directDeps.concat(indirectDeps);

--- a/test/fixtures/clean.test.js
+++ b/test/fixtures/clean.test.js
@@ -15,6 +15,7 @@ var filesToClean = [
         'node_modules/awesome_package/.gitignore',
         'node_modules/awesome_package/Gruntfile.js',
         'node_modules/yo/node_modules/yoyo/yo.pyc',
+        'node_modules/eslint/node_modules/rxjs/_esm2015/internal/observable/dom/fetch.js.map',
         'node_modules/yo/node_modules/yoyo/Changes'
     ],
 


### PR DESCRIPTION
Peer dependencies with sub folders where not cleaned so far. The
reason for that is that the generated glob was only about the direct
sub folder and deeper structures were ignored.