### PR TITLE
 chore: add changelog entry for supported node versions in next release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+3.0.0 (pending)
+=====
+
+* Support for Node.js 10.x and newer only.
+
 2.2.2
 =====
 


### PR DESCRIPTION
fs-extra causes test failures in 8.x and 6.x, but those are EOL release lines so we can drop them.