### PR TITLE
chore: remove test/tmp before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "git://github.com/inikulin/dmn.git"
   },
   "scripts": {
-    "test": "rm -rf test/fixtures/node_modules && node test/run_tests.js"
+    "test": "rm -rf test/fixtures/node_modules test/tmp && node test/run_tests.js"
   },
   "dependencies": {
     "char-spinner": "1.0.1",


### PR DESCRIPTION
Sometimes previous failed runs can leave files lying around that mess up
the first test run.