### PR TITLE
fix: make patterns work with top-level dependencies

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -3,7 +3,7 @@ var path = require('path'),
     glob = require('fast-glob'),
     console = require('./console_ex'),
     targets = require('./targets');
-    patterns = ['(*/|**/node_modules/**/)(' + targets.join('|') + ')'];
+    patterns = ['**/(' + targets.join('|') + ')'];
 
 
 function confirm(what) {


### PR DESCRIPTION
`glob` is executed with `node_modules` as cwd, so the pattern shouldn't include `node_modules`. This change allows to find files anywhere in the tree below the first `node_modules`.